### PR TITLE
Add TAP commands mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,12 +173,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "endian-type"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
-
-[[package]]
 name = "env_filter"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -223,17 +217,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
-name = "fd-lock"
-version = "4.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
-dependencies = [
- "cfg-if",
- "rustix",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -256,15 +239,6 @@ dependencies = [
  "libc",
  "pkg-config",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "home"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
-dependencies = [
- "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -330,15 +304,6 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
-
-[[package]]
-name = "nibble_vec"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
-dependencies = [
- "smallvec",
-]
 
 [[package]]
 name = "nix"
@@ -428,16 +393,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "radix_trie"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
-dependencies = [
- "endian-type",
- "nibble_vec",
-]
-
-[[package]]
 name = "rustix"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -459,13 +414,10 @@ dependencies = [
  "bitflags",
  "cfg-if",
  "clipboard-win",
- "fd-lock",
- "home",
  "libc",
  "log",
  "memchr",
  "nix",
- "radix_trie",
  "unicode-segmentation",
  "unicode-width",
  "utf8parse",
@@ -497,12 +449,6 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
-name = "smallvec"
-version = "1.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "strsim"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,6 +76,7 @@ dependencies = [
  "hidapi",
  "log",
  "num_enum",
+ "rustyline",
  "thiserror",
 ]
 
@@ -99,6 +100,12 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "clap"
@@ -142,6 +149,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -155,6 +171,12 @@ checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 
 [[package]]
 name = "env_filter"
@@ -195,6 +217,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
+name = "fd-lock"
+version = "4.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
+dependencies = [
+ "cfg-if",
+ "rustix",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -217,6 +256,15 @@ dependencies = [
  "libc",
  "pkg-config",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "home"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
+dependencies = [
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -282,6 +330,27 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "nibble_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
 
 [[package]]
 name = "num_enum"
@@ -359,6 +428,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
+]
+
+[[package]]
 name = "rustix"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -368,6 +447,28 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustyline"
+version = "16.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62fd9ca5ebc709e8535e8ef7c658eb51457987e48c98ead2be482172accc408d"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "clipboard-win",
+ "fd-lock",
+ "home",
+ "libc",
+ "log",
+ "memchr",
+ "nix",
+ "radix_trie",
+ "unicode-segmentation",
+ "unicode-width",
+ "utf8parse",
  "windows-sys 0.59.0",
 ]
 
@@ -396,6 +497,12 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "strsim"
@@ -466,6 +573,18 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ crc32fast = "1.2"
 anyhow = "1.0"
 clap = { version = "4.0", features = ["derive", "wrap_help"] }
 env_logger = { version = "0.11", default-features = false, features = ["auto-color", "humantime"] }
+rustyline = "16.0.0"
 
 [profile.release]
 strip = "symbols"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ crc32fast = "1.2"
 anyhow = "1.0"
 clap = { version = "4.0", features = ["derive", "wrap_help"] }
 env_logger = { version = "0.11", default-features = false, features = ["auto-color", "humantime"] }
-rustyline = "16.0.0"
+rustyline = { version = "16.0.0", default-features = false }
 
 [profile.release]
 strip = "symbols"

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ OPTIONS:
 SUBCOMMANDS:
     list         List all connected Bose HID devices (vendor ID 0x05a7)
     info         Get information about a specific device not in DFU mode
+    tap          Run TAP commands on a specific device not in DFU mode
     enter-dfu    Put a device into DFU mode
     leave-dfu    Take a device out of DFU mode
     download     Write firmware to a device in DFU mode
@@ -127,6 +128,12 @@ To update a device, you'll need to run at least `bose-dfu enter-dfu`, `bose-dfu
 download`, and `bose-dfu leave-dfu`, in that order. The other subcommands help
 you inspect the current state of devices and firmware files. Notable is `info`,
 which tells you the current firmware version a device is running.
+
+The `tap` subcommand can be used to start an interactvice shell with the device
+allowing you to send maintenance commands to the device, useful for servicing
+purposes (like putting the device into shipmode when changing the battery).
+Refer to your products service manual for available commands. To exit the shell
+you may use a single `.`, `<CTRL-C>` or `<CTRL-D>`.
 
 Subcommands that perform an operation on a device support arguments for
 selecting which device to talk to.  You can use `-p` to select by USB product

--- a/README.md
+++ b/README.md
@@ -129,10 +129,10 @@ download`, and `bose-dfu leave-dfu`, in that order. The other subcommands help
 you inspect the current state of devices and firmware files. Notable is `info`,
 which tells you the current firmware version a device is running.
 
-The `tap` subcommand can be used to start an interactvice shell with the device
+The `tap` subcommand can be used to start an interactive shell with the device
 allowing you to send maintenance commands to the device, useful for servicing
 purposes (like putting the device into shipmode when changing the battery).
-Refer to your products service manual for available commands. To exit the shell
+Refer to your product's service manual for available commands. To exit the shell
 you may use a single `.`, `<CTRL-C>` or `<CTRL-D>`.
 
 Subcommands that perform an operation on a device support arguments for

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,9 @@ use thiserror::Error;
 
 use bose_dfu::device_ids::{DeviceCompat, DeviceMode, UsbId, identify_device};
 use bose_dfu::dfu_file::parse as parse_dfu_file;
-use bose_dfu::protocol::{download, ensure_idle, enter_dfu, leave_dfu, read_info_field, run_tap_commands};
+use bose_dfu::protocol::{
+    download, ensure_idle, enter_dfu, leave_dfu, read_info_field, run_tap_commands,
+};
 
 #[derive(Parser, Debug)]
 #[command(version, about)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,9 +4,8 @@ use hidapi::{DeviceInfo, HidApi, HidDevice};
 use log::{info, warn};
 use rustyline::DefaultEditor;
 use rustyline::error::ReadlineError;
-use std::env;
 use std::io::Read;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use thiserror::Error;
 
 use bose_dfu::device_ids::{DeviceCompat, DeviceMode, UsbId, identify_device};
@@ -193,17 +192,8 @@ fn list_cmd(hidapi: &HidApi) {
     }
 }
 
-pub fn tap_command_loop(device: &HidDevice) -> Result<()> {
-    const HISTORY_NAME: &str = ".bose-dfu_history";
-
+fn tap_command_loop(device: &HidDevice) -> Result<()> {
     let mut rl = DefaultEditor::new()?;
-    let history_file = match env::home_dir() {
-        Some(home_path) => home_path.join(HISTORY_NAME),
-        None => PathBuf::from(HISTORY_NAME),
-    };
-    if rl.load_history(&history_file).is_err() {
-        println!("No previous history.");
-    }
 
     loop {
         let readline = rl.readline("> ");
@@ -214,6 +204,7 @@ pub fn tap_command_loop(device: &HidDevice) -> Result<()> {
                 } else if line == "." {
                     break;
                 }
+                rl.add_history_entry(line.as_str())?;
 
                 let result = run_tap_command(device, line.as_bytes());
                 println!("{result:?}");
@@ -231,10 +222,6 @@ pub fn tap_command_loop(device: &HidDevice) -> Result<()> {
                 break;
             }
         }
-    }
-
-    if rl.save_history(&history_file).is_err() {
-        println!("Cant save history.")
     }
 
     Ok(())

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -210,7 +210,7 @@ pub fn run_tap_commands(device: &HidDevice) -> Result<(), Error> {
         // Packet captures indicate that "lc" is also a valid field type for some devices, but on mine
         // it always returns a bus error (both when I send it and when the official updater does).
         request_report[0] = TAP_REPORT_ID;
-        request_report[1..tap_bytes.len()+1].copy_from_slice(tap_bytes);
+        request_report[1..tap_bytes.len() + 1].copy_from_slice(tap_bytes);
 
         device
             .send_feature_report(&request_report)
@@ -227,7 +227,10 @@ pub fn run_tap_commands(device: &HidDevice) -> Result<(), Error> {
             "reading TAP command response",
         )?;
 
-        trace!("Raw {:?} TAP command response: {:02x?}", tap_command, response_report);
+        trace!(
+            "Raw {:?} TAP command response: {:02x?}",
+            tap_command, response_report
+        );
 
         // Result is all the bytes after the report ID and before the first NUL.
         let result = response_report[1..].split(|&x| x == 0).next().unwrap();

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -139,8 +139,8 @@ pub enum InfoField {
     CurrentFirmware,
 }
 
-// Run a "TAP command" on the device. This is the general way to communicate with Bose DFU devices
-// 'device' must NOT be in DFU mode.
+/// Run a "TAP command" on the device. This is the general way to communicate with Bose devices.
+/// 'device' must NOT be in DFU mode.
 pub fn run_tap_command(device: &HidDevice, tap_bytes: &[u8]) -> Result<String, Error> {
     const TAP_REPORT_ID: u8 = 2;
     const TAP_REPORT_LEN: usize = 126;


### PR DESCRIPTION
A minor change to allow a sort of terminal command mode (a la Polycomm.zip) used for servicing. In particular useful to put a device in shipmode for a more safe battery replacement, see [Soundlink mini II service manual](https://riverparkinc.com/wp-content/uploads/2016/02/SLminiII_SM.pdf) page 30 and on for some example uses...