### PR TITLE
Added config for Bose Soundwear Companion speaker

### DIFF
--- a/70-bose-dfu.rules
+++ b/70-bose-dfu.rules
@@ -11,3 +11,6 @@ SUBSYSTEM=="hidraw", ATTRS{idVendor}=="05a7", ATTRS{idProduct}=="4009", TAG+="ua
 
 # QuietComfort 35 II, DFU mode
 SUBSYSTEM=="hidraw", ATTRS{idVendor}=="05a7", ATTRS{idProduct}=="4020", TAG+="uaccess"
+
+# Soundwear, DFU mode
+SUBSYSTEM=="hidraw", ATTRS{idVendor}=="05a7", ATTRS{idProduct}=="4017", TAG+="uaccess"


### PR DESCRIPTION
Device was previously on Main 1.2.3.782
After update: Current firmware: Main 3.0.3.835

Purchased used on ebay. Prev owner reported that it showed three lights suggesting it was malfunctioning.
Updating firmware fixed it 🚀
